### PR TITLE
kube-bench utility image tag updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The following table lists the required ZCSPM configuration parameters along with
 | `clusterHosting`                   | Kubernetes Cluster hosting to use                               | `AKS`                        |    `Yes`    |
 | `zcspmEnvironment`                   | ZCSPM environment to use                                | `prod`                        |    `No`    |
 | `images.zcspmAgentImage.repository`                   | Container image to use                                | `cloudneeticorp/zcspm-agent`                        |    `No`    |
-| `images.kubebenchImage.tag`                          | Container image tag to deploy                         | `2.11`                                        |    `No`    |
+| `images.zcspmAgentImage.tag`                          | Container image tag to deploy                         | `2.11`                                        |    `No`    |
 | `images.pullPolicy`                   | Container pull policy                                 | `Always`                               |    `No`    |
 | `cronjob.schedule`                   | Schedule for the CronJob                              | `0 12 * * *`                                  |    `No`    |
 | `cronjob.concurrencyPolicy`          | `Allow|Forbid|Replace` concurrent jobs                | `Forbid`                                     |    `No`    |

--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ The following table lists the required ZCSPM configuration parameters along with
 | `zcspmAPIKey`                   | ZCSPM API Key                                | `-`                        |   `Yes`       |
 | `clusterHosting`                   | Kubernetes Cluster hosting to use                               | `AKS`                        |    `Yes`    |
 | `zcspmEnvironment`                   | ZCSPM environment to use                                | `prod`                        |    `No`    |
-| `image.repository`                   | Container image to use                                | `cloudneeticorp/zcspm-agent`                        |    `No`    |
-| `image.tag`                          | Container image tag to deploy                         | `2.11`                                        |    `No`    |
-| `image.pullPolicy`                   | Container pull policy                                 | `Always`                               |    `No`    |
+| `images.zcspmAgentImage.repository`                   | Container image to use                                | `cloudneeticorp/zcspm-agent`                        |    `No`    |
+| `images.kubebenchImage.tag`                          | Container image tag to deploy                         | `2.11`                                        |    `No`    |
+| `images.pullPolicy`                   | Container pull policy                                 | `Always`                               |    `No`    |
 | `cronjob.schedule`                   | Schedule for the CronJob                              | `0 12 * * *`                                  |    `No`    |
 | `cronjob.concurrencyPolicy`          | `Allow|Forbid|Replace` concurrent jobs                | `Forbid`                                     |    `No`    |
 | `cronjob.failedJobsHistoryLimit`     | Specify the number of failed Jobs to keep             | `3`                                          |    `No`    |

--- a/charts/zcspm-agent/Chart.yaml
+++ b/charts/zcspm-agent/Chart.yaml
@@ -20,7 +20,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.0
+version: 0.10.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/zcspm-agent/templates/zcspm-agent.yaml
+++ b/charts/zcspm-agent/templates/zcspm-agent.yaml
@@ -46,7 +46,8 @@ spec:
           restartPolicy: OnFailure
           initContainers:
           - name: metadata-scanner
-            image: aquasec/kube-bench:latest
+            image: {{ .Values.images.kubebenchImage.repository}}:{{ .Values.images.kubebenchImage.tag }}
+            imagePullPolicy: {{ .Values.images.imagePullPolicy}}
             command: ["/bin/sh", "-c"]
             args: ["kube-bench --benchmark cis-1.5 >> /var/log/kube-bench/kube-bench.log 2>&1"]
             volumeMounts:
@@ -66,8 +67,8 @@ spec:
               mountPath: /var/log/kube-bench
           containers:
           - name: {{ template "zcspm-agent.name" . }}
-            image: {{ .Values.image.repository}}:{{ .Values.image.tag }}
-            imagePullPolicy: {{ .Values.image.imagePullPolicy}}
+            image: {{ .Values.images.zcspmAgentImage.repository}}:{{ .Values.images.zcspmAgentImage.tag }}
+            imagePullPolicy: {{ .Values.images.imagePullPolicy}}
             env:
               - name: CLUSTER_NAME
                 valueFrom:

--- a/charts/zcspm-agent/values.yaml
+++ b/charts/zcspm-agent/values.yaml
@@ -18,10 +18,16 @@ zcspmEnvironment: "prod"
 zcspmAPIKey: "<zcspmAPIKey>"
 zcspmAPIAppSecret: "<zcspmAPIAppSecret>"
 
-image:
-  repository: cloudneeticorp/zcspm-agent
-  tag: "2.11"
-  imagePullPolicy: Always
+images:
+  imagePullPolicy: Always   #Default image pull policy for all images
+
+  zcspmAgentImage: 
+    repository: cloudneeticorp/zcspm-agent
+    tag: "2.11"
+
+  kubebenchImage: 
+    repository: aquasec/kube-bench
+    tag: "0.6.0"
 
 cronjob:
   # At 12:00 every day

--- a/charts/zcspm-agent/values.yaml
+++ b/charts/zcspm-agent/values.yaml
@@ -22,6 +22,7 @@ images:
 # Default image pull policy for all images
   imagePullPolicy: Always
 
+# Details of images being used in the chart 
   zcspmAgentImage: 
     repository: cloudneeticorp/zcspm-agent
     tag: "2.11"

--- a/charts/zcspm-agent/values.yaml
+++ b/charts/zcspm-agent/values.yaml
@@ -19,7 +19,7 @@ zcspmAPIKey: "<zcspmAPIKey>"
 zcspmAPIAppSecret: "<zcspmAPIAppSecret>"
 
 images:
-  imagePullPolicy: Always   #Default image pull policy for all images
+  imagePullPolicy: Always   # Default image pull policy for all images
 
   zcspmAgentImage: 
     repository: cloudneeticorp/zcspm-agent

--- a/charts/zcspm-agent/values.yaml
+++ b/charts/zcspm-agent/values.yaml
@@ -22,12 +22,12 @@ images:
 # Default image pull policy for all images
   imagePullPolicy: Always
 
-# Details of images being used in the chart 
-  zcspmAgentImage: 
+# Details of images being used in the chart
+  zcspmAgentImage:
     repository: cloudneeticorp/zcspm-agent
     tag: "2.11"
 
-  kubebenchImage: 
+  kubebenchImage:
     repository: aquasec/kube-bench
     tag: "0.6.0"
 

--- a/charts/zcspm-agent/values.yaml
+++ b/charts/zcspm-agent/values.yaml
@@ -19,7 +19,8 @@ zcspmAPIKey: "<zcspmAPIKey>"
 zcspmAPIAppSecret: "<zcspmAPIAppSecret>"
 
 images:
-  imagePullPolicy: Always   # Default image pull policy for all images
+# Default image pull policy for all images
+  imagePullPolicy: Always
 
   zcspmAgentImage: 
     repository: cloudneeticorp/zcspm-agent


### PR DESCRIPTION
- Parameterized image tag for kube-bench image
- Using stable image tag 0.6.0, due to stability issues with latest image versions.